### PR TITLE
Update SuntechProtocolEncoder.java

### DIFF
--- a/src/org/traccar/protocol/SuntechProtocolEncoder.java
+++ b/src/org/traccar/protocol/SuntechProtocolEncoder.java
@@ -28,7 +28,7 @@ public class SuntechProtocolEncoder extends StringProtocolEncoder {
             case Command.TYPE_REBOOT_DEVICE:
                 return formatCommand(command, "SA200CMD;{%s};02;Reboot\r", Command.KEY_UNIQUE_ID);
             case Command.TYPE_POSITION_SINGLE:
-                return formatCommand(command, "SA200GTR;{%s};02;\r", Command.KEY_UNIQUE_ID);
+                return formatCommand(command, "SA200CMD;{%s};02;StatusReq\r", Command.KEY_UNIQUE_ID);
             case Command.TYPE_OUTPUT_CONTROL:
                 if (command.getAttributes().containsKey(Command.KEY_DATA)) {
                     if (command.getAttributes().get(Command.KEY_DATA).equals("1")) {
@@ -43,6 +43,10 @@ public class SuntechProtocolEncoder extends StringProtocolEncoder {
                 return formatCommand(command, "SA200CMD;{%s};02;Enable1\r", Command.KEY_UNIQUE_ID);
             case Command.TYPE_ENGINE_RESUME:
                 return formatCommand(command, "SA200CMD;{%s};02;Disable1\r", Command.KEY_UNIQUE_ID);
+                case Command.TYPE_ENGINE_STOP:
+                return formatCommand(command, "SA200CMD;{%s};02;Enable2\r", Command.KEY_UNIQUE_ID);
+            case Command.TYPE_ENGINE_RESUME:
+                return formatCommand(command, "SA200CMD;{%s};02;Disable2\r", Command.KEY_UNIQUE_ID);        
             default:
                 Log.warning(new UnsupportedOperationException(command.getType()));
                 break;


### PR DESCRIPTION
With the new lines of code, you can control the output 02 of the module.

The command ("SA200GTR; {% s}; 02; \ r") do not get any position in response modules, ST-240, ST-340 - Suntech
